### PR TITLE
Fix/ Twitch API on prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "confusables": "^0.3.3",
     "eris": "github:caf203/eris#dev",
     "fastify": "^2.10.0",
+    "fastify-helmet": "^3.0.2",
     "get-urls": "^9.2.0",
     "i18next": "^19.0.1",
     "i18next-node-fs-backend": "^2.1.3",

--- a/src/services/hooks/index.ts
+++ b/src/services/hooks/index.ts
@@ -1,5 +1,6 @@
 import fastifyBuilder from 'fastify'
 import twitchRouters from './../twitch/hooks'
+import helmet from 'fastify-helmet'
 
 const fastify = fastifyBuilder({
   logger: {
@@ -7,11 +8,15 @@ const fastify = fastifyBuilder({
   }
 })
 
+fastify.register(helmet, {
+  hidePoweredBy: {
+    // :p
+    setTo: 'PHP 4.2.0'
+  }
+})
+
 fastify.register(twitchRouters, { prefix: '/twitch' })
 
 export default (port: number) => {
-  fastify.listen(port || 3000, (err, address) => {
-    if (err) throw err
-    fastify.log.info(`server listening on ${address}`)
-  })
+  fastify.listen(port || 3000, '0.0.0.0')
 }


### PR DESCRIPTION
By default, Fastify only accepts connection from the localhost. This makes it so it accepts from all network interfaces.