### PR TITLE
Check if the mute role is present in the guild.

### DIFF
--- a/src/lib/utils/moderation.ts
+++ b/src/lib/utils/moderation.ts
@@ -179,6 +179,9 @@ export default class {
       const guild = this.Gamer.guilds.get(log.guildID)
       if (!guild) continue
 
+      // If the mute role is not present in the guild, skip.
+      if (!guild.roles.has(guildSettings.moderation.roleIDs.mute)) continue
+
       const language = this.Gamer.getLanguage(guild.id)
       const member = await this.Gamer.helpers.discord.fetchMember(guild, log.userID)
       if (!member) continue


### PR DESCRIPTION
This code would check if the mute role, set in the guild config, is present. If it's not it could lead to Missing Role errors.