### PR TITLE
fix(guildMemberAdd.ts): Fixes "Missing Permissions" on new member.

### DIFF
--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -29,32 +29,32 @@ export default class extends Event {
 
     // In case other bots/users add a role to the user we do this check
     if (botMember.permission.has('manageRoles') && botsHighestRole.position > membersHighestRole.position) {
-      if (
-        guildSettings.moderation.roleIDs.mute &&
-        guildSettings.moderation.users.mutedUserIDs.includes(member.id) &&
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        guild.roles.get(guildSettings.moderation.roleIDs.mute)?.position! < botsHighestRole.position
-      )
-        member.addRole(guildSettings.moderation.roleIDs.mute, language(`moderation/mute:GUILDMEMBERADD_MUTED`))
-
+      if (guildSettings.moderation.roleIDs.mute && guildSettings.moderation.users.mutedUserIDs.includes(member.id)) {
+        const muteRole = guild.roles.get(guildSettings.moderation.roleIDs.mute)
+        if (!muteRole) return
+        if (muteRole.position > botsHighestRole.position) return
+        member.addRole(muteRole.id, language(`moderation/mute:GUILDMEMBERADD_MUTED`))
+      }
       // Verify Or AutoRole
 
       // If verification is enabled and the role id is set add the verify role
-      if (
-        guildSettings.verify.enabled &&
-        guildSettings.verify.roleID &&
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        guild.roles.get(guildSettings.verify.roleID)?.position! < botsHighestRole.position
-      )
+      if (guildSettings.verify.enabled && guildSettings.verify.roleID) {
+        const verifyRole = guild.roles.get(guildSettings.verify.roleID)
+        if (!verifyRole) return
+        if (verifyRole.position > botsHighestRole.position) return
         member.addRole(guildSettings.verify.roleID, language(`basic/verify:VERIFY_ACTIVATE`))
+      }
       // If discord verification is disabled and auto role is set give the member the auto role
       else if (
         !guildSettings.verify.discordVerificationStrictnessEnabled &&
         guildSettings.moderation.roleIDs.autorole &&
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        guild.roles.get(guildSettings.moderation.roleIDs.autorole)?.position! < botsHighestRole.position
-      )
+        guild.roles.has(guildSettings.moderation.roleIDs.autorole)
+      ) {
+        const autoRole = guild.roles.get(guildSettings.moderation.roleIDs.autorole)
+        if (!autoRole) return
+        if (autoRole.position > botsHighestRole.position) return
         member.addRole(guildSettings.moderation.roleIDs.autorole, language(`basic/verify:AUTOROLE_ASSIGNED`))
+      }
     }
 
     // Welcome Message

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,8 +1,7 @@
 import Event from '../lib/structures/Event'
 import { TextChannel, Member, Guild } from 'eris'
 import GamerClient from '../lib/structures/GamerClient'
-import { MessageEmbed } from 'helperis'
-import { highestRole } from 'helperis'
+import { MessageEmbed, highestRole } from 'helperis'
 
 export default class extends Event {
   async execute(guild: Guild, member: Member) {
@@ -33,20 +32,27 @@ export default class extends Event {
       if (
         guildSettings.moderation.roleIDs.mute &&
         guildSettings.moderation.users.mutedUserIDs.includes(member.id) &&
-        guild.roles.has(guildSettings.moderation.roleIDs.mute)
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        guild.roles.get(guildSettings.moderation.roleIDs.mute)?.position! < botsHighestRole.position
       )
         member.addRole(guildSettings.moderation.roleIDs.mute, language(`moderation/mute:GUILDMEMBERADD_MUTED`))
 
       // Verify Or AutoRole
 
       // If verification is enabled and the role id is set add the verify role
-      if (guildSettings.verify.enabled && guildSettings.verify.roleID && guild.roles.has(guildSettings.verify.roleID))
+      if (
+        guildSettings.verify.enabled &&
+        guildSettings.verify.roleID &&
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        guild.roles.get(guildSettings.verify.roleID)?.position! < botsHighestRole.position
+      )
         member.addRole(guildSettings.verify.roleID, language(`basic/verify:VERIFY_ACTIVATE`))
       // If discord verification is disabled and auto role is set give the member the auto role
       else if (
         !guildSettings.verify.discordVerificationStrictnessEnabled &&
         guildSettings.moderation.roleIDs.autorole &&
-        guild.roles.has(guildSettings.moderation.roleIDs.autorole)
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        guild.roles.get(guildSettings.moderation.roleIDs.autorole)?.position! < botsHighestRole.position
       )
         member.addRole(guildSettings.moderation.roleIDs.autorole, language(`basic/verify:AUTOROLE_ASSIGNED`))
     }

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -31,18 +31,16 @@ export default class extends Event {
     if (botMember.permission.has('manageRoles') && botsHighestRole.position > membersHighestRole.position) {
       if (guildSettings.moderation.roleIDs.mute && guildSettings.moderation.users.mutedUserIDs.includes(member.id)) {
         const muteRole = guild.roles.get(guildSettings.moderation.roleIDs.mute)
-        if (!muteRole) return
-        if (muteRole.position > botsHighestRole.position) return
-        member.addRole(muteRole.id, language(`moderation/mute:GUILDMEMBERADD_MUTED`))
+        if (muteRole && muteRole.position < botsHighestRole.position)
+          member.addRole(muteRole.id, language(`moderation/mute:GUILDMEMBERADD_MUTED`))
       }
       // Verify Or AutoRole
 
       // If verification is enabled and the role id is set add the verify role
       if (guildSettings.verify.enabled && guildSettings.verify.roleID) {
         const verifyRole = guild.roles.get(guildSettings.verify.roleID)
-        if (!verifyRole) return
-        if (verifyRole.position > botsHighestRole.position) return
-        member.addRole(guildSettings.verify.roleID, language(`basic/verify:VERIFY_ACTIVATE`))
+        if (verifyRole && verifyRole.position < botsHighestRole.position)
+          member.addRole(guildSettings.verify.roleID, language(`basic/verify:VERIFY_ACTIVATE`))
       }
       // If discord verification is disabled and auto role is set give the member the auto role
       else if (
@@ -51,9 +49,8 @@ export default class extends Event {
         guild.roles.has(guildSettings.moderation.roleIDs.autorole)
       ) {
         const autoRole = guild.roles.get(guildSettings.moderation.roleIDs.autorole)
-        if (!autoRole) return
-        if (autoRole.position > botsHighestRole.position) return
-        member.addRole(guildSettings.moderation.roleIDs.autorole, language(`basic/verify:AUTOROLE_ASSIGNED`))
+        if (autoRole && autoRole.position < botsHighestRole.position)
+          member.addRole(guildSettings.moderation.roleIDs.autorole, language(`basic/verify:AUTOROLE_ASSIGNED`))
       }
     }
 


### PR DESCRIPTION
This could be caused because the bot's highest role is under the role(s) it has to give.